### PR TITLE
[Scala] Fixed single type expression continuation after annotation

### DIFF
--- a/Scala/Scala.sublime-syntax
+++ b/Scala/Scala.sublime-syntax
@@ -1106,13 +1106,17 @@ contexts:
     - match: '{{typeid}}'
       scope: support.type.scala
       set: single-type-expression-tail
+    - match: (?=@{{plainid}})
+      set: single-type-expression-tail
     - include: base-type-expression
-    # the '@' indicates the beginning of an annotation
-    - match: '(?=@)'
-      pop: true
-    - match: '(?=[\s$,\)\}\]])'
+    - match: '(?=[\s,\)\}\]])'
       pop: true
   single-type-expression-tail:
+    - match: (?=@{{plainid}})
+      set:
+        - include: annotation
+        - match: '(?=\S)'
+          set: single-type-expression-tail
     - match: '[\.#]'
       scope: punctuation.accessor.scala
       set: single-type-expression

--- a/Scala/syntax_test_scala.scala
+++ b/Scala/syntax_test_scala.scala
@@ -1301,6 +1301,10 @@ trait Function0[@specialized(Unit, Int, Double) T] {
   def apply: T
 }
 
-x: Foo @volatile with Bar
-//          ^^ storage.modifier.annotation
-//               ^^ keyword.declaration
+x: Foo @volatile with Bar @foo.bar @bar with Baz
+//          ^^ storage.modifier.annotation.scala
+//               ^^ keyword.declaration.scala
+//                    ^^^ support.class.scala
+//                        ^^^^^^^^ storage.modifier.annotation.scala
+//                                 ^^^^ storage.modifier.annotation.scala
+//                                           ^^^ support.class.scala


### PR DESCRIPTION
The full test case this fixes:

```scala
x: Foo @volatile with Bar @foo.bar @bar with Baz
//          ^^ storage.modifier.annotation.scala
//               ^^ keyword.declaration.scala
//                    ^^^ support.class.scala
//                        ^^^^^^^^ storage.modifier.annotation.scala
//                                 ^^^^ storage.modifier.annotation.scala
//                                           ^^^ support.class.scala
```